### PR TITLE
Fix for issue #45

### DIFF
--- a/js/adapt-contrib-slider.js
+++ b/js/adapt-contrib-slider.js
@@ -179,18 +179,16 @@ define(function(require) {
         },
 
         onKeyDown: function(event) {
-            if(event.which == 9) return; // tab key
+            if(event.which == 9 || !event.ctrlKey) return; // tab key
             event.preventDefault();
             
             var newItemIndex = this.getIndexFromValue(this.model.get('_selectedItem').value);
             
             switch (event.which) {
-                case 40: // ↓ down
-                case 37: // ← left
+                case 188: // < left
                     newItemIndex = Math.max(newItemIndex - 1, 0);
                     break;
-                case 38: // ↑ up
-                case 39: // → right
+                case 190: // > right
                     newItemIndex = Math.min(newItemIndex + 1, this.model.get('_items').length - 1);
                     break;
             }
@@ -403,11 +401,12 @@ define(function(require) {
         // this should add the current slider value to the marker
         showNumber: function(show) {
             var $scaleMarker = this.$('.slider-scale-marker');
+            var $scaleMarkerNumber = $scaleMarker.find('.slider-scale-marker-number');
             if(this.model.get("_showNumber")) {
                 if(show) {
-                    $scaleMarker.html(this.model.get('_selectedItem').value);
+                    $scaleMarkerNumber.html(this.model.get('_selectedItem').value);
                 } else {
-                    $scaleMarker.html = "";
+                    $scaleMarkerNumber.html = "";
                 }
             }
         }

--- a/less/slider.less
+++ b/less/slider.less
@@ -153,6 +153,18 @@
         display: block;
     }
 
+    .slider-scale-marker-prefix {
+        position: absolute;
+        top: -1px;
+        left: -25px;
+        height: 1px;
+        width: 1px;
+        z-index: 0;
+        overflow: hidden;
+        padding: 0;
+        margin: 0;
+    }
+
     .slider-line {
         display: block;
         width: 2px;

--- a/templates/slider.hbs
+++ b/templates/slider.hbs
@@ -10,7 +10,12 @@
                 <div class="slider-modelranges"></div>
                 <div class="slider-markers"></div>
                 <div class="slider-answer component-item-color component-item-text-color"></div>
-                <div class="slider-scale-marker component-item-color component-item-text-color"></div>
+                <div class="slider-scale-marker component-item-color component-item-text-color" aria-live="assertive" aria-atomic="true">
+                    {{#if _accessibility._ariaLabels.sliderScaleMarkerPrefix}}
+                        <div class="slider-scale-marker-prefix">{{_accessibility._ariaLabels.sliderScaleMarkerPrefix}}</div>
+                    {{/if}}
+                    <div class="slider-scale-marker-number"></div>
+                </div>
             </div>
             <div class="slider-background">
                 <div class="slider-item component-item {{#unless _isEnabled}}{{#if correct}}correct{{else}}incorrect{{/if}}{{/unless}}">


### PR DESCRIPTION
New keyboard shortcuts for moving slider are ctrl comma and ctrl period.

N.B. additional ARIA accessibility label required:

_accessibility._ariaLabels.sliderScaleMarkerPrefix, e.g:

"Slider value "

_accessibility._ariaLabels.sliderHandle text should be updated
accordingly to:

"Slider handle. Hold down the CTRL key and use the comma and full stop
keys to move the slider left and right to give your answer. Then tab to
the submit button below and press enter."