### PR TITLE
Hook into _canShowMarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ guide the learner’s interaction with the component.
 **_questionWeight** (number): A number which reflects the significance of the question in relation to the other questions in the course. This number is used in calculations of the final score reported to the LMS.  
 
 **_canShowModelAnswer** (boolean): Setting this to `false` prevents the [**_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) from being displayed. The default is `true`.
+
+**_canShowMarking** (boolean): Setting this to `false` prevents ticks and crosses being displayed on question completion. The default is `true`.
   
 **_recordInteraction** (boolean) Determines whether or not the learner's answers will be recorded to the LMS via cmi.interactions. Default is `true`. For further information, see the entry for `_shouldRecordInteractions` in the README for [adapt-contrib-spoor](https://github.com/adaptlearning/adapt-contrib-spoor).
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-slider",
   "version": "2.1.0",
-  "framework": "^2.0.0",
+  "framework": "^2.0.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-slider",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-slider%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "displayName" : "Slider",

--- a/example.json
+++ b/example.json
@@ -13,6 +13,7 @@
     "_shouldDisplayAttempts": false,
     "_questionWeight":1,
     "_canShowModelAnswer": true,
+    "_canShowMarking": true,
     "_recordInteraction": true,
     "_showNumber": true,
     "_showScaleIndicator": true,

--- a/js/adapt-contrib-slider.js
+++ b/js/adapt-contrib-slider.js
@@ -337,6 +337,8 @@ define([
         // This is important and should give the user feedback on how they answered the question
         // Normally done through ticks and crosses by adding classes
         showMarking: function() {
+            if (!this.model.get("_canShowMarking")) return;
+
             this.$('.slider-widget').removeClass('correct incorrect')
                 .addClass(this.model.get('_selectedItem').correct ? 'correct' : 'incorrect');
         },

--- a/js/adapt-contrib-slider.js
+++ b/js/adapt-contrib-slider.js
@@ -337,7 +337,7 @@ define([
         // This is important and should give the user feedback on how they answered the question
         // Normally done through ticks and crosses by adding classes
         showMarking: function() {
-            if (!this.model.get("_canShowMarking")) return;
+            if (!this.model.get('_canShowMarking')) return;
 
             this.$('.slider-widget').removeClass('correct incorrect')
                 .addClass(this.model.get('_selectedItem').correct ? 'correct' : 'incorrect');

--- a/less/slider.less
+++ b/less/slider.less
@@ -143,7 +143,7 @@
             .dir-rtl & {
                 transform: rotateY(180deg);
                 -webkit-transform: rotateY(180deg);
-                -ms-transform: rotate(180deg);
+                -ms-transform: rotateY(180deg);
                 /*IE9 does not support 3D transform*/
                 -moz-transform: rotateY(180deg);
                 -o-transform: rotateY(180deg);

--- a/properties.schema
+++ b/properties.schema
@@ -46,6 +46,14 @@
       "validators": [],
       "help": "Select 'true' to allow the user to view the 'model answer' should they answer the question incorrectly"
     },
+    "_canShowMarking": {
+      "type": "boolean",
+      "default": true,
+      "title": "Display Marking",
+      "inputType": { "type": "Boolean", "options": [ true, false ] },
+      "validators": [],
+      "help": "Select 'true' to display ticks and crosses on question completion"
+    },
     "_shouldDisplayAttempts": {
       "type":"boolean",
       "required":false,

--- a/templates/slider.hbs
+++ b/templates/slider.hbs
@@ -1,6 +1,6 @@
 <div class="slider-inner component-inner" role="region" aria-label="{{_globals._components._slider.ariaRegion}}" {{#if _globals._components._slider.ariaRegion}}tabindex="0"{{/if}}>
     {{> component this}}
-    <div class="slider-widget component-widget {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{else}}incorrect{{/if}} {{/if}} {{/unless}}">
+    <div class="slider-widget component-widget {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if ../_canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}} {{/if}} {{/unless}}">
         <div class="slider-holder clearfix">
             <div class="slider-scale-labels">
                 <div class="slider-scale-start" tabindex="0" role="region">{{labelStart}}</div>


### PR DESCRIPTION
Avoids adding correctness classes to widget if `_canShowMarking` is false.

Please only merge once the new version of the framework has been released (v2.0.11).

Original issue: adaptlearning/adapt_framework#1046.