### PR TITLE
Fixes the issue of the number on the marker getting flip over in RTL …

### DIFF
--- a/js/adapt-contrib-slider.js
+++ b/js/adapt-contrib-slider.js
@@ -175,7 +175,8 @@ define([
                     left: newPosition
                   }, {
                     duration: 200,
-                    easing: "linear"
+                    easing: "linear",
+                    mobileHA: false
                   });
         },
 


### PR DESCRIPTION
By default, velocity.js sets the property 'mobileHA' to true to animate it properly on very older versions of mobile.

http://velocityjs.org/#mobileHA

Fixes https://github.com/adaptlearning/adapt_framework/issues/1878.