### PR TITLE
Issue/#2283 - fix to show user feedback when number scale is hidden

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-slider",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "framework": ">=2.0.13",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-slider",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-slider",
-  "version": "2.3.3",
+  "version": "2.3.2",
   "framework": ">=2.0.16",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-slider",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-slider",
-  "version": "2.3.2",
-  "framework": ">=2.0.13",
+  "version": "2.3.3",
+  "framework": ">=2.0.16",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-slider",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
   "displayName" : "Slider",

--- a/js/sliderModel.js
+++ b/js/sliderModel.js
@@ -39,7 +39,7 @@ define([
                 items.push({
                     value: i,
                     selected: false,
-                    correct : answer ? i === answer : (i >= range._bottom && i <= range._top)
+                    correct : answer ? i == answer : (i >= range._bottom && i <= range._top)
                 });
             }
 

--- a/js/sliderModel.js
+++ b/js/sliderModel.js
@@ -39,7 +39,7 @@ define([
                 items.push({
                     value: i,
                     selected: false,
-                    correct : answer ? i == answer : (i >= range._bottom && i <= range._top)
+                    correct : answer ? i === Number(answer) : (i >= range._bottom && i <= range._top)
                 });
             }
 

--- a/js/sliderView.js
+++ b/js/sliderView.js
@@ -239,7 +239,7 @@ define([
 
         showScale: function () {
             var $markers = this.$('.slider-markers').empty();
-            
+
             if (this.model.get('_showScale') === false) {
               $markers.eq(0).css({display: 'none'});
               this.$('.slider-scale-number').css(

--- a/js/sliderView.js
+++ b/js/sliderView.js
@@ -239,13 +239,13 @@ define([
 
         showScale: function () {
             var $markers = this.$('.slider-markers').empty();
-            
+
             if (this.model.get('_showScale') === false) {
-              $markers.eq(0).css({display: 'none'});
-              this.$('.slider-scale-number').css(
-                this.model.get('_showScaleIndicator') ? {visibility: 'hidden'} : {display: 'none'}
-              );
-              return;
+                $markers.eq(0).css({display: 'none'});
+                this.$('.slider-scale-number').css(
+                    this.model.get('_showScaleIndicator') ? {visibility: 'hidden'} : {display: 'none'}
+                );
+                return;
             }
 
             var $scaler = this.$('.slider-scaler');
@@ -261,8 +261,8 @@ define([
             var $numbers = this.$('.slider-scale-number');
 
             if (this.model.get('_showScaleNumbers') === false) {
-              $numbers.css('display', 'none');
-              return;
+                $numbers.css('display', 'none');
+                return;
             }
 
             var scaleWidth = $scaler.width();
@@ -332,9 +332,7 @@ define([
             var middleAnswer = answers[Math.floor(answers.length / 2)];
             this.animateToPosition(this.mapIndexToPixels(this.getIndexFromValue(middleAnswer)));
 
-            if (this.model.get('_showScaleIndicator') === true) {
-              this.showModelAnswers(answers);
-            }
+            this.showModelAnswers(answers);
 
             this.setSliderValue(middleAnswer);
         },

--- a/js/sliderView.js
+++ b/js/sliderView.js
@@ -239,15 +239,13 @@ define([
 
         showScale: function () {
             var $markers = this.$('.slider-markers').empty();
+            
             if (this.model.get('_showScale') === false) {
-                $markers.eq(0).css({display: 'none'});
-                this.$('.slider-scale-numbers *:not(".slider-scale-marker")').css(
-                    this.model.get('_showScaleIndicator') ? {visibility: 'hidden'} : {display: 'none'}
-                );
-                this.$('.slider-scale-numbers .slider-modelranges').css(
-                    this.model.get('_showScaleIndicator') ? {visibility: 'visible'} : {display: 'none'}
-                ); 
-                return;
+              $markers.eq(0).css({display: 'none'});
+              this.$('.slider-scale-number').css(
+                this.model.get('_showScaleIndicator') ? {visibility: 'hidden'} : {display: 'none'}
+              );
+              return;
             }
 
             var $scaler = this.$('.slider-scaler');
@@ -260,13 +258,14 @@ define([
 
         showScaleNumbers: function () {
             var $scaler = this.$('.slider-scaler');
+            var $numbers = this.$('.slider-scale-number');
+
             if (this.model.get('_showScaleNumbers') === false) {
-                this.$('.slider-scale-numbers *:not(".slider-scale-marker")').css('display', 'none');
-                return;
+              $numbers.css('display', 'none');
+              return;
             }
 
             var scaleWidth = $scaler.width();
-            var $numbers = this.$('.slider-scale-number');
             this.model.get('_items').forEach(function(item, index) {
                 var $number = $numbers.eq(index);
                 var newLeft = Math.round($number.data('normalisedPosition') * scaleWidth);

--- a/js/sliderView.js
+++ b/js/sliderView.js
@@ -244,6 +244,9 @@ define([
                 this.$('.slider-scale-numbers *:not(".slider-scale-marker")').css(
                     this.model.get('_showScaleIndicator') ? {visibility: 'hidden'} : {display: 'none'}
                 );
+                this.$('.slider-scale-numbers .slider-modelranges').css(
+                    this.model.get('_showScaleIndicator') ? {visibility: 'visible'} : {display: 'none'}
+                ); 
                 return;
             }
 

--- a/js/sliderView.js
+++ b/js/sliderView.js
@@ -239,7 +239,7 @@ define([
 
         showScale: function () {
             var $markers = this.$('.slider-markers').empty();
-
+            
             if (this.model.get('_showScale') === false) {
               $markers.eq(0).css({display: 'none'});
               this.$('.slider-scale-number').css(
@@ -332,7 +332,9 @@ define([
             var middleAnswer = answers[Math.floor(answers.length / 2)];
             this.animateToPosition(this.mapIndexToPixels(this.getIndexFromValue(middleAnswer)));
 
-            this.showModelAnswers(answers);
+            if (this.model.get('_showScaleIndicator') === true) {
+              this.showModelAnswers(answers);
+            }
 
             this.setSliderValue(middleAnswer);
         },


### PR DESCRIPTION
I would appreciate your feedback on the best way to fix Issue #2283.

As the ticket I raised says, when the user hides the number scale, gets the answer wrong, clicks show correct answer, the indicator is hidden so they don't get any feedback.

Resolves https://github.com/adaptlearning/adapt_framework/issues/2283.