### PR TITLE
Fix: add scale context to slider start and end labels (fixes #156)

### DIFF
--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -99,16 +99,18 @@ export default function Slider (props) {
         <div className="slider__label-container js-slider-label-container">
 
           {labelStart &&
-          <div className="slider__label-start" aria-label={_globals._components._slider.labelStart}>
+          <div className="slider__label-start">
             <div className="slider__label-start-inner">
+              <span className="aria-label">{_globals._components._slider.labelStart} {_scaleStart}</span>
               {labelStart}
             </div>
           </div>
           }
 
           {labelEnd &&
-          <div className="slider__label-end" aria-label={_globals._components._slider.labelEnd}>
+          <div className="slider__label-end">
             <div className="slider__label-end-inner">
+              <span className="aria-label">{_globals._components._slider.labelEnd} {_scaleEnd}</span>
               {labelEnd}
             </div>
           </div>


### PR DESCRIPTION
- Remove `aria-label` attribute (this was replacing `labelStart` and `labelEnd` when reading)
- Add `aria-label span` containing scale context (distinguish start or end of scale and scale value). This is read alongside `labelStart` and `labelEnd`.

How `slider__label-start` should now read:
'Start of the scale, 1, incomplete'

How `slider__label-end` should now read:
'End of the scale, 10, complete'

This PR (in addition to `ariaQuestion` that's already been implemented) resolves https://github.com/adaptlearning/adapt-contrib-slider/issues/156

The initial request for slider label context was raised via confidenceSlider https://github.com/adaptlearning/adapt-contrib-confidenceSlider/issues/82 and will require the same implementation applied.

