### PR TITLE
Fix: String defaults for scaleStepPrefix and scaleStepSuffix

### DIFF
--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -28,8 +28,8 @@ export default function Slider (props) {
     _showNumber,
     _showScaleNumbers,
     _showScaleIndicator,
-    scaleStepPrefix,
-    scaleStepSuffix
+    scaleStepPrefix = '',
+    scaleStepSuffix = ''
   } = props;
 
   const sliderNumberSelectionRef = useRef(0);


### PR DESCRIPTION
fixes #185

### Fix
* Provided string defaults to stop jsx converting  `undefined` to `"undefined"`

