### PR TITLE
Fix: included scale step in input slider jsx (fix #187)

### DIFF
--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -19,6 +19,7 @@ export default function Slider (props) {
     _selectedItem,
     _scaleStart,
     _scaleEnd,
+    _scaleStep,
     _marginDir,
     onNumberSelected,
     getIndexFromValue,
@@ -178,6 +179,7 @@ export default function Slider (props) {
             value={selectedValue}
             min={_scaleStart}
             max={_scaleEnd}
+            step={_scaleStep}
             aria-valuenow={selectedValue}
             aria-valuemin={_scaleStart}
             aria-valuemax={_scaleEnd}


### PR DESCRIPTION
https://github.com/adaptlearning/adapt-contrib-slider/issues/187

### Fix
_scaleStep included in props and assigned to steps within the input slider. This will ensure correct increment/decrement when scale step is above 1.