### PR TITLE
Update: Remove ariaQuestion placeholder text (fixes #196)

### DIFF
--- a/example.json
+++ b/example.json
@@ -9,7 +9,7 @@
         "displayTitle": "Slider type component",
         "body": "Question text here",
         "instruction": "Drag the slider to make your choice and select Submit.",
-        "ariaQuestion": "Question text specifically for screen readers.",
+        "ariaQuestion": "",
         "ariaScaleName": "Scale name specifically for screen readers.",
         "_attempts": 1,
         "_shouldDisplayAttempts": false,


### PR DESCRIPTION
Prevent placeholder text being copied over and left in accessible courses. Property description is noted in README and schema help/description for reference.

Fixes https://github.com/adaptlearning/adapt-contrib-slider/issues/196

Missing `ariaQuestion` property added to [wiki](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes/_edit#question-model-attributes).

Note, [`ariaScaleName`](https://github.com/adaptlearning/adapt-contrib-slider/blob/da358d2bafe52eff18f1b108e22b462da41719c0/example.json#L13) also contains placeholder text however I decided to leave this as is. `ariaScaleName` is a required property but because the value is content specific there isn't an appropriate default to set so placeholder text makes sense here.