### PR TITLE
Fix: Vertically center number in selection circle (fixes #198)

### DIFF
--- a/less/slider.less
+++ b/less/slider.less
@@ -27,6 +27,9 @@
   &__number,
   &__number-selection,
   &__number-model-answer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     position: absolute;
     top: 0;
     .transform(translateX(-50%));


### PR DESCRIPTION
Fix #198 

### Fix
* Vertically centers the number in the selection circle 

### Testing
Set the `@body-size` variable to 1.5rem. Compare with the default value of 1rem. The number should be centered in both cases.
