### PR TITLE
Fix: missing attribute values causing runtime error

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ guide the learner’s interaction with the component.
 
 **labelEnd** (string): Text/characters that appear at the end of the slider scale.
 
-**\_scaleStart** (number): This value is the numeric start of the scale. It is used to calculate the slider's position on the scale.
+**\_scaleStart** (number): This value is the numeric start of the scale. It is used to calculate the slider's position on the scale. The default is `1`.
 
-**\_scaleEnd** (number): This value is the numeric end of the scale. It is used to calculate the slider's position on the scale.
+**\_scaleEnd** (number): This value is the numeric end of the scale. It is used to calculate the slider's position on the scale. The default is `10`.
 
-**\_scaleStep** (number): Defines the amount the scale should be incremented by.
+**\_scaleStep** (number): Defines the amount the scale should be incremented by. The default is `1`.
 
 **scaleStepPrefix** (string): Prefix to add to each slider step. For example, a "$" can be used as a prefix to indicate currency in dollars (ex. $100).
 

--- a/js/SliderModel.js
+++ b/js/SliderModel.js
@@ -5,6 +5,9 @@ export default class SliderModel extends QuestionModel {
 
   defaults() {
     return QuestionModel.resultExtend('defaults', {
+      _scaleStart: 1,
+      _scaleEnd: 10,
+      _scaleStep: 1,
       _showScale: true,
       _showScaleNumbers: true,
       _showScaleIndicator: true,

--- a/js/SliderModel.js
+++ b/js/SliderModel.js
@@ -1,5 +1,6 @@
 import Adapt from 'core/js/adapt';
 import QuestionModel from 'core/js/models/questionModel';
+import logging from 'core/js/logging';
 
 export default class SliderModel extends QuestionModel {
 
@@ -17,7 +18,11 @@ export default class SliderModel extends QuestionModel {
 
   init() {
     QuestionModel.prototype.init.call(this);
-
+    // safeguard against `_scaleStep` of 0 or less
+    if (this.get('_scaleStep') <= 0) {
+      logging.warn(`\`_scaleStep\` must be a positive number, restoring default of 1 for ${this.get('_id')}`);
+      this.set('_scaleStep', 1);
+    }
     this.setupModelItems();
     this.selectDefaultItem();
   }

--- a/js/SliderModel.js
+++ b/js/SliderModel.js
@@ -52,7 +52,7 @@ export default class SliderModel extends QuestionModel {
     const range = this.get('_correctRange');
     const start = this.get('_scaleStart');
     const end = this.get('_scaleEnd');
-    const step = this.get('_scaleStep') || 1;
+    const step = this.get('_scaleStep');
 
     const dp = this.getDecimalPlaces(step);
 
@@ -180,7 +180,7 @@ export default class SliderModel extends QuestionModel {
       return answers;
     }
     let answer = bottom;
-    const step = this.get('_scaleStep') || 1;
+    const step = this.get('_scaleStep');
     while (answer <= top) {
       answers.push(answer);
       answer += step;

--- a/js/SliderView.js
+++ b/js/SliderView.js
@@ -23,7 +23,7 @@ class SliderView extends QuestionView {
   // this shoud give the index of item using given slider value
   getIndexFromValue(value) {
     value = parseFloat(value);
-    const step = this.model.get('_scaleStep') ?? 1;
+    const step = this.model.get('_scaleStep');
     return this.model.get('_items').reduce((found, item) => {
       if (found) return found;
       if (item.value === value) return item;

--- a/properties.schema
+++ b/properties.schema
@@ -187,7 +187,7 @@
     "_scaleEnd": {
       "type": "number",
       "required": true,
-      "default": 1,
+      "default": 10,
       "title": "Scale End",
       "inputType": "Number",
       "validators": ["required", "number"],

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -116,7 +116,7 @@
         "_scaleEnd": {
           "type": "number",
           "title": "Scale end number",
-          "default": 1
+          "default": 10
         },
         "_scaleStep": {
           "type": "number",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -122,7 +122,8 @@
           "type": "number",
           "title": "Scale step",
           "description": "The amount the scale should increment by",
-          "default": 1
+          "default": 1,
+          "exclusiveMinimum": 0
         },
         "scaleStepPrefix": {
           "type": "string",


### PR DESCRIPTION
Fixes #204.

### Fix
* Added default attribute values for `_scaleStart`, `_scaleEnd` and `_scaleStep`.
* Restrict `_scaleStep` to a positive number.

### Update
* Changed  `_scaleEnd` schema default from 1 to 10.

