### PR TITLE
Fix: aria-valuetext attribute added to the slider to read out scaleStepPrefix/scaleStepSuffix (fixes #211)

### DIFF
--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -177,7 +177,7 @@ export default function Slider (props) {
           <input className='slider__item-input js-slider-item-input'
             type='range'
             aria-label={ariaScaleName}
-            aria-valuetext={`${scaleStepPrefix} ${selectedValue} ${scaleStepSuffix}`}
+            aria-valuetext={(scaleStepPrefix || scaleStepSuffix) && `${scaleStepPrefix} ${selectedValue} ${scaleStepSuffix}`}
             value={selectedValue}
             min={_scaleStart}
             max={_scaleEnd}

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -177,6 +177,7 @@ export default function Slider (props) {
           <input className='slider__item-input js-slider-item-input'
             type='range'
             aria-label={ariaScaleName}
+            aria-valuetext={`${scaleStepPrefix} ${selectedValue} ${scaleStepSuffix}`}
             value={selectedValue}
             min={_scaleStart}
             max={_scaleEnd}

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -177,7 +177,7 @@ export default function Slider (props) {
           <input className='slider__item-input js-slider-item-input'
             type='range'
             aria-label={ariaScaleName}
-            aria-valuetext={(scaleStepPrefix || scaleStepSuffix) && `${scaleStepPrefix} ${selectedValue} ${scaleStepSuffix}`}
+            aria-valuetext={(scaleStepPrefix || scaleStepSuffix) ? `${scaleStepPrefix} ${selectedValue} ${scaleStepSuffix}` : null}
             value={selectedValue}
             min={_scaleStart}
             max={_scaleEnd}


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#211 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* aria-valuetext attribute added to the slider to read out scaleStepPrefix/scaleStepSuffix(fixes #211)


