### PR TITLE
New: Added support for _canShowCorrectness

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ guide the learner’s interaction with the component.
 
 **\_canShowModelAnswer** (boolean): Setting this to `false` prevents the [**_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) from being displayed. The default is `true`.
 
+**\_canShowCorrectness** (boolean): Setting this to `true` replaces the associated `_canShowModelAnswer` toggle button and displays correctness directly on the component. The default is `false`.
+
 **\_canShowFeedback** (boolean): Setting this to `false` disables feedback, so it is not shown to the user. The default is `true`.
 
 **\_canShowMarking** (boolean): Setting this to `false` prevents ticks and crosses being displayed on question completion. The default is `true`.

--- a/example.json
+++ b/example.json
@@ -15,6 +15,7 @@
         "_shouldDisplayAttempts": false,
         "_questionWeight": 1,
         "_canShowModelAnswer": true,
+        "_canShowCorrectness": false,
         "_canShowFeedback": true,
         "_canShowMarking": true,
         "_recordInteraction": true,

--- a/less/slider.less
+++ b/less/slider.less
@@ -59,6 +59,10 @@
     position: absolute;
     top: 0;
     .transform(translateX(-50%));
+
+    .dir-rtl & {
+      .transform(translateX(-50%) rotateY(180deg));
+    }
   }
 
   &__correct-icon .icon {

--- a/less/slider.less
+++ b/less/slider.less
@@ -39,6 +39,36 @@
     }
   }
 
+  // Correctness state
+  &__state {
+    position: relative;
+    min-height: 1.5rem;
+    // Indent half the width of the range slider handle either side
+    margin-left: @slider-handle-width / 2;
+    margin-right: @slider-handle-width / 2;
+
+    .dir-rtl & {
+      .transform(rotateY(180deg));
+    }
+  }
+
+  &__icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    top: 0;
+    .transform(translateX(-50%));
+  }
+
+  &__correct-icon .icon {
+    .icon-tick;
+  }
+
+  &__incorrect-icon .icon {
+    .icon-cross;
+  }
+
   // Scale
   &__scale-container {
     position: relative;

--- a/properties.schema
+++ b/properties.schema
@@ -113,6 +113,15 @@
       "validators": [],
       "help": "Allow the user to view the 'model answer' if they answer the question incorrectly?"
     },
+    "_canShowCorrectness": {
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "title": "Display correctness",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "If enabled, this replaces the associated 'model answer' toggle button and displays correctness directly on the component."
+    },
     "_canShowFeedback": {
       "type": "boolean",
       "required": true,

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -65,6 +65,12 @@
           "description": "Allow the user to view the 'model answer' if they answer the question incorrectly",
           "default": true
         },
+        "_canShowCorrectness": {
+          "type": "boolean",
+          "title": "Enable to display correctness",
+          "description": "If enabled, this replaces the associated 'model answer' toggle button and displays correctness directly on the component",
+          "default": false
+        },
         "_canShowFeedback": {
           "type": "boolean",
           "title": "Enable feedback",

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -6,6 +6,8 @@ export default function Slider (props) {
     _id,
     _globals,
     _shouldShowMarking,
+    _canShowModelAnswer,
+    _canShowCorrectness,
     _isInteractionComplete,
     _isCorrectAnswerShown,
     _isEnabled,
@@ -58,7 +60,10 @@ export default function Slider (props) {
         className={classes([
           'component__widget slider__widget',
           !_isEnabled && 'is-disabled',
-          _isInteractionComplete && 'is-complete is-submitted show-user-answer',
+          _isInteractionComplete && 'is-complete is-submitted',
+          _isInteractionComplete && !_canShowCorrectness && !_isCorrectAnswerShown && 'show-user-answer',
+          _isInteractionComplete && _canShowModelAnswer && _isCorrectAnswerShown && 'show-correct-answer',
+          _isInteractionComplete && _canShowCorrectness && 'show-correctness',
           _shouldShowMarking && _isCorrect && 'is-correct',
           _shouldShowMarking && !_isCorrect && 'is-incorrect'
         ])}

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -153,14 +153,14 @@ export default function Slider (props) {
         </div>
 
         {/* annotate the answer range correctness */}
-        {_isInteractionComplete && _canShowCorrectness &&
+        {_canShowCorrectness &&
           <div className="slider__state">
             {_items.slice(0).map((item, index) =>
               <div
                 className={classes([
                   'slider__icon',
-                  item.correct && 'slider__correct-icon',
-                  !item.correct && 'slider__incorrect-icon'
+                  _isInteractionComplete && item.correct && 'slider__correct-icon',
+                  _isInteractionComplete && !item.correct && 'slider__incorrect-icon'
                 ])}
                 style={{ left: `${calculatePercentFromIndex(index)}%` }}
                 key={item.value}

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -103,7 +103,7 @@ export default function Slider (props) {
 
           {/* annotate the scale */}
           {_showScale && _showScaleNumbers &&
-            _items.map(({ index, value }) => {
+            _items.map(({ index, value, correct }) => {
               return (
                 <div
                   key={index}
@@ -114,7 +114,7 @@ export default function Slider (props) {
                   onClick={e => onNumberSelected(parseFloat(e.currentTarget.getAttribute('data-id')))}
                 >
                   {_shouldShowMarking && _isInteractionComplete &&
-                  <span className="aria-label">{`${_isCorrect ? ariaLabels.correct : ariaLabels.incorrect}, ${selectedValue === value ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${scaleStepPrefix}${value}${scaleStepSuffix}`}</span>
+                  <span className="aria-label">{`${correct ? ariaLabels.correct : ariaLabels.incorrect}, ${selectedValue === value ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${scaleStepPrefix}${value}${scaleStepSuffix}`}</span>
                   }
                   <span aria-hidden="true">{scaleStepPrefix}{value}{scaleStepSuffix}</span>
                 </div>

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -1,3 +1,4 @@
+import Adapt from 'core/js/adapt';
 import React, { useRef } from 'react';
 import { classes, templates } from 'core/js/reactHelpers';
 
@@ -50,6 +51,8 @@ export default function Slider (props) {
   const selectedValue = _isCorrectAnswerShown ? getCorrectRangeMidpoint() : (_selectedItem?.value ?? _scaleStart);
   const selectedIndex = getIndexFromValue(selectedValue);
   const selectedWidth = calculatePercentFromIndex(selectedIndex);
+
+  const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
 
   return (
     <div className="component__inner slider__inner">
@@ -106,11 +109,14 @@ export default function Slider (props) {
                   key={index}
                   className="slider__number js-slider-number js-slider-number-click"
                   data-id={value}
-                  aria-hidden="true"
+                  aria-disabled= {_isInteractionComplete || null}
                   style={{ left: `${calculatePercentFromIndex(index)}%` }}
                   onClick={e => onNumberSelected(parseFloat(e.currentTarget.getAttribute('data-id')))}
                 >
-                  {scaleStepPrefix}{value}{scaleStepSuffix}
+                  {_shouldShowMarking && _isInteractionComplete &&
+                  <span className="aria-label">{`${_isCorrect ? ariaLabels.correct : ariaLabels.incorrect}, ${selectedValue === value ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${scaleStepPrefix}${value}${scaleStepSuffix}`}</span>
+                  }
+                  <span aria-hidden="true">{scaleStepPrefix}{value}{scaleStepSuffix}</span>
                 </div>
               );
             })
@@ -154,7 +160,7 @@ export default function Slider (props) {
 
         {/* annotate the answer range correctness */}
         {_canShowCorrectness &&
-          <div className="slider__state">
+          <div className="slider__state" aria-hidden="true">
             {_items.slice(0).map((item, index) =>
               <div
                 className={classes([

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -152,6 +152,25 @@ export default function Slider (props) {
           }
         </div>
 
+        {/* annotate the answer range correctness */}
+        {_isInteractionComplete && _canShowCorrectness &&
+          <div className="slider__state">
+            {_items.slice(0).map((item, index) =>
+              <div
+                className={classes([
+                  'slider__icon',
+                  item.correct && 'slider__correct-icon',
+                  !item.correct && 'slider__incorrect-icon'
+                ])}
+                style={{ left: `${calculatePercentFromIndex(index)}%` }}
+                key={item.value}
+              >
+                <span className='icon'></span>
+              </div>
+            )}
+          </div>
+        }
+
         {/* always present start and end notches */}
         <div className="slider__scale-container js-slider-scale">
           <div className="slider__scale-notch slider__scale-notch-start" />


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3597

Allows option `_canShowCorrectness` instead of  `_canShowModelAnswer`, to replace the associated toggle button and display correctness directly on the component.

### New
* Added support for `_canShowCorrectness`
* `.show-correctness` widget class appended for consistency with other question components. Note, there's no associated styling currently.
* Correctness ARIA applied to slider numbers. For consistency with other question items, selectable items are marked up with an `aria-label` consisting of correctness, selection and value.

![slider_standard](https://github.com/user-attachments/assets/fde0f40a-de7c-4ac2-80a5-d0ab2f4e442b)

#### Requires
ref https://github.com/adaptlearning/adapt-contrib-core/pull/582