### PR TITLE
New: added `getInteractionObject` to align with other questions and for data reporting

### DIFF
--- a/js/SliderModel.js
+++ b/js/SliderModel.js
@@ -153,6 +153,24 @@ export default class SliderModel extends QuestionModel {
     this.set('_score', score);
   }
 
+  getInteractionObject() {
+    return {
+      correctResponsesPattern: this.getCorrectResponsesPattern()
+    }
+  }
+
+  getCorrectResponsesPattern() {
+    const correctAnswer = this.get('_correctAnswer');
+    if (correctAnswer) return [correctAnswer];
+    const correctRange = this.get('_correctRange');
+    if (!correctRange) return null;
+    const bottom = correctRange?._bottom ?? '';
+    const top = correctRange?._top ?? '';
+    return [
+      `${bottom}[:]${top}`
+    ];
+  }
+
   /**
   * Used by adapt-contrib-spoor to get the user's answers in the format required by the cmi.interactions.n.student_response data field
   */

--- a/js/SliderModel.js
+++ b/js/SliderModel.js
@@ -164,8 +164,8 @@ export default class SliderModel extends QuestionModel {
     if (correctAnswer) return [correctAnswer];
     const correctRange = this.get('_correctRange');
     if (!correctRange) return null;
-    const bottom = correctRange?._bottom ?? '';
-    const top = correctRange?._top ?? '';
+    const bottom = correctRange._bottom ?? '';
+    const top = correctRange._top ?? '';
     return [
       `${bottom}[:]${top}`
     ];


### PR DESCRIPTION
Fixes #214.

### New
* added `getInteractionObject` to align with other questions and for data reporting. The `correctResponsesPattern` uses the `numeric` SCORM 2004 and xAPI pattern as SCORM 1.2 doesn't account for ranges.


Relevant to https://github.com/adaptlearning/adapt-contrib-spoor/pull/321/

https://github.com/adaptlearning/scorm_docs/blob/master/SCORM%202004/4th%20Edition/SCORM_2004_4ED_v1_1_RTE_20090814.pdf

![image](https://github.com/user-attachments/assets/41bf6eef-48dd-46cb-840a-27e4b63c42db)
![image](https://github.com/user-attachments/assets/a04dba99-0012-4691-8687-e062386fcbb3)

