### PR TITLE
New: Add classes and spans for prefixes / suffixes (fixes #233)

### DIFF
--- a/less/slider.less
+++ b/less/slider.less
@@ -106,11 +106,6 @@
     left: 100%;
   }
 
-  &__scale-step-suffix,
-  &__scale-step-prefix {
-    display: inline-block;
-  }
-
   // Slider bar
   &__item {
     position: relative;

--- a/less/slider.less
+++ b/less/slider.less
@@ -41,7 +41,7 @@
 
   &__scale-step-prefix,
   &__scale-step-suffix {
-    white-space: pre-wrap;
+    white-space: pre;
   }
 
   // Correctness state

--- a/less/slider.less
+++ b/less/slider.less
@@ -39,6 +39,11 @@
     }
   }
 
+  &__scale-step-prefix,
+  &__scale-step-suffix {
+    white-space: pre-wrap;
+  }
+
   // Correctness state
   &__state {
     position: relative;
@@ -99,6 +104,11 @@
 
   &__scale-notch-end {
     left: 100%;
+  }
+
+  &__scale-step-suffix,
+  &__scale-step-prefix {
+    display: inline-block;
   }
 
   // Slider bar

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -116,7 +116,11 @@ export default function Slider (props) {
                   {_shouldShowMarking && _isInteractionComplete &&
                   <span className="aria-label">{`${correct ? ariaLabels.correct : ariaLabels.incorrect}, ${selectedValue === value ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${scaleStepPrefix}${value}${scaleStepSuffix}`}</span>
                   }
-                  <span aria-hidden="true">{scaleStepPrefix}{value}{scaleStepSuffix}</span>
+                  <span aria-hidden="true">
+                    {scaleStepPrefix && <span className='slider__scale-step-prefix'>{scaleStepPrefix}</span>}
+                    {value}
+                    {scaleStepSuffix && <span className='slider__scale-step-suffix'>{scaleStepSuffix}</span>}
+                  </span>
                 </div>
               );
             })
@@ -132,9 +136,11 @@ export default function Slider (props) {
                     key={correctAnswer}
                     style={{ left: `${calculatePercentFromIndex(getIndexFromValue(correctAnswer))}%` }}
                   >
-                    {_showNumber &&
-                      `${scaleStepPrefix}${correctAnswer}${scaleStepSuffix}`
-                    }
+                    {_showNumber && <>
+                      {scaleStepPrefix && <span className='slider__scale-step-prefix'>{scaleStepPrefix}</span>}
+                      {correctAnswer}
+                      {scaleStepSuffix && <span className='slider__scale-step-suffix'>{scaleStepSuffix}</span>}
+                    </>}
                   </div>
                 );
               })
@@ -151,9 +157,11 @@ export default function Slider (props) {
               tabIndex="-1"
               ref={sliderNumberSelectionRef}
             >
-              {_showNumber &&
-                `${scaleStepPrefix}${_selectedItem.value}${scaleStepSuffix}`
-              }
+              {_showNumber && <>
+                {scaleStepPrefix && <span className='slider__scale-step-prefix'>{scaleStepPrefix}</span>}
+                {_selectedItem.value}
+                {scaleStepSuffix && <span className='slider__scale-step-suffix'>{scaleStepSuffix}</span>}
+              </>}
             </div>
           }
         </div>

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -230,7 +230,7 @@ export default function Slider (props) {
           <input className='slider__item-input js-slider-item-input'
             type='range'
             aria-label={ariaScaleName}
-            aria-valuetext={(scaleStepPrefix || scaleStepSuffix) ? `${scaleStepPrefix} ${selectedValue} ${scaleStepSuffix}` : null}
+            aria-valuetext={(scaleStepPrefix || scaleStepSuffix) ? `${scaleStepPrefix}${selectedValue}${scaleStepSuffix}` : null}
             value={selectedValue}
             min={_scaleStart}
             max={_scaleEnd}

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -62,6 +62,8 @@ export default function Slider (props) {
       <div
         className={classes([
           'component__widget slider__widget',
+          scaleStepPrefix && 'has-scale-step-prefix',
+          scaleStepSuffix && 'has-scale-step-suffix',
           !_isEnabled && 'is-disabled',
           _isInteractionComplete && 'is-complete is-submitted',
           _isInteractionComplete && !_canShowCorrectness && !_isCorrectAnswerShown && 'show-user-answer',

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -119,9 +119,13 @@ export default function Slider (props) {
                   <span className="aria-label">{`${correct ? ariaLabels.correct : ariaLabels.incorrect}, ${selectedValue === value ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${scaleStepPrefix}${value}${scaleStepSuffix}`}</span>
                   }
                   <span aria-hidden="true">
-                    {scaleStepPrefix && <span className='slider__scale-step-prefix'>{scaleStepPrefix}</span>}
+                    {scaleStepPrefix &&
+                    <span className='slider__scale-step-prefix' dangerouslySetInnerHTML={{ __html: scaleStepPrefix }} />
+                    }
                     {value}
-                    {scaleStepSuffix && <span className='slider__scale-step-suffix'>{scaleStepSuffix}</span>}
+                    {scaleStepSuffix &&
+                    <span className='slider__scale-step-suffix' dangerouslySetInnerHTML={{ __html: scaleStepSuffix }} />
+                    }
                   </span>
                 </div>
               );
@@ -139,9 +143,13 @@ export default function Slider (props) {
                     style={{ left: `${calculatePercentFromIndex(getIndexFromValue(correctAnswer))}%` }}
                   >
                     {_showNumber && <>
-                      {scaleStepPrefix && <span className='slider__scale-step-prefix'>{scaleStepPrefix}</span>}
+                      {scaleStepPrefix &&
+                      <span className='slider__scale-step-prefix' dangerouslySetInnerHTML={{ __html: scaleStepPrefix }} />
+                      }
                       {correctAnswer}
-                      {scaleStepSuffix && <span className='slider__scale-step-suffix'>{scaleStepSuffix}</span>}
+                      {scaleStepSuffix &&
+                      <span className='slider__scale-step-suffix' dangerouslySetInnerHTML={{ __html: scaleStepSuffix }} />
+                      }
                     </>}
                   </div>
                 );
@@ -160,9 +168,13 @@ export default function Slider (props) {
               ref={sliderNumberSelectionRef}
             >
               {_showNumber && <>
-                {scaleStepPrefix && <span className='slider__scale-step-prefix'>{scaleStepPrefix}</span>}
+                {scaleStepPrefix &&
+                <span className='slider__scale-step-prefix' dangerouslySetInnerHTML={{ __html: scaleStepPrefix }} />
+                }
                 {_selectedItem.value}
-                {scaleStepSuffix && <span className='slider__scale-step-suffix'>{scaleStepSuffix}</span>}
+                {scaleStepSuffix &&
+                <span className='slider__scale-step-suffix' dangerouslySetInnerHTML={{ __html: scaleStepSuffix }} />
+                }
               </>}
             </div>
           }


### PR DESCRIPTION
Fixes #233

### New
* When `scaleStepPrefix` or `scaleStepSuffix` are set, `has-scale-step-prefix` and `has-scale-step-suffix` modifier classes are now added, giving theme authors a useful CSS hook.
* Prefix and suffix values are now wrapped in `<span>` elements in all three visible render locations: scale number labels, correct answer range indicator, and selected value indicator
* The span wrappers enable targeted styling like hiding on small screens via media queries (e.g. showing `$5` on desktop but just `5` on mobile). This would need to be customized by the theme author, though.

### Testing
1. Configure a slider with `scaleStepPrefix` (e.g. `$`) and/or `scaleStepSuffix` (e.g. ` days`)
2. Verify the prefix/suffix text is wrapped in the expected span elements in the DOM
3. Verify `has-scale-step-prefix` / `has-scale-step-suffix` classes appear on `slider__widget`
4. Verify aria label strings are unaffected (prefix/suffix still render as plain text in screen reader spans)
5. Verify a slider with no prefix/suffix is unchanged — no extra spans or classes

### Related
https://github.com/adaptlearning/adapt-contrib-vanilla/pull/592 - Adds improved styling when prefixes and suffixes are present.

Posted via collaboration with Claude Code