### PR TITLE
Fix: Show full correct range and improve post-submit slider state (fixes #184)

### DIFF
--- a/less/slider.less
+++ b/less/slider.less
@@ -167,7 +167,7 @@
       cursor: default;
     }
 
-    .show-correct-answer & {
+    .show-correct-answer.is-incorrect & {
       box-shadow: none;
       background-color: transparent;
     }

--- a/less/slider.less
+++ b/less/slider.less
@@ -164,9 +164,12 @@
     cursor: pointer;
 
     .is-disabled & {
+      cursor: default;
+    }
+
+    .show-correct-answer & {
       box-shadow: none;
       background-color: transparent;
-      cursor: default;
     }
   }
 

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -49,8 +49,8 @@ export default function Slider (props) {
     return index / (_items.length - 1) * 100;
   };
 
-  const isCorrectRangeShown = _isInteractionComplete && _isCorrect && _canShowModelAnswer && correctAnswers.length > 1;
-  const isModelRangeShown = _isCorrectAnswerShown || isCorrectRangeShown;
+  const isModelRangeShown = _isCorrectAnswerShown ||
+    (_isInteractionComplete && _isCorrect && _canShowModelAnswer && correctAnswers.length > 1);
 
   const selectedValue = _isCorrectAnswerShown ? getCorrectRangeMidpoint() : (_selectedItem?.value ?? _scaleStart);
   const selectedIndex = getIndexFromValue(selectedValue);
@@ -75,8 +75,8 @@ export default function Slider (props) {
           scaleStepSuffix && 'has-scale-step-suffix',
           !_isEnabled && 'is-disabled',
           _isInteractionComplete && 'is-complete is-submitted',
-          _isInteractionComplete && !_canShowCorrectness && !_isCorrectAnswerShown && 'show-user-answer',
-          _isInteractionComplete && _canShowModelAnswer && _isCorrectAnswerShown && 'show-correct-answer',
+          _isInteractionComplete && !_canShowCorrectness && !isModelRangeShown && 'show-user-answer',
+          _isInteractionComplete && _canShowModelAnswer && isModelRangeShown && 'show-correct-answer',
           _isInteractionComplete && _canShowCorrectness && 'show-correctness',
           _shouldShowMarking && _isCorrect && 'is-correct',
           _shouldShowMarking && !_isCorrect && 'is-incorrect'
@@ -168,7 +168,7 @@ export default function Slider (props) {
 
           {/* annotate the selected value */}
           <div className="slider__number-answer"></div>
-          {_showScaleIndicator && !isCorrectRangeShown &&
+          {_showScaleIndicator &&
             <div
               className="slider__number-selection js-slider-number-selection a11y-ignore"
               aria-hidden="true"

--- a/templates/slider.jsx
+++ b/templates/slider.jsx
@@ -39,18 +39,27 @@ export default function Slider (props) {
 
   const sliderNumberSelectionRef = useRef(0);
 
+  const correctAnswers = getCorrectAnswers();
+
   const getCorrectRangeMidpoint = () => {
-    const answers = getCorrectAnswers();
-    return answers[Math.floor(answers.length / 2)];
+    return correctAnswers[Math.floor(correctAnswers.length / 2)];
   };
 
   const calculatePercentFromIndex = (index) => {
     return index / (_items.length - 1) * 100;
   };
 
+  const isCorrectRangeShown = _isInteractionComplete && _isCorrect && _canShowModelAnswer && correctAnswers.length > 1;
+  const isModelRangeShown = _isCorrectAnswerShown || isCorrectRangeShown;
+
   const selectedValue = _isCorrectAnswerShown ? getCorrectRangeMidpoint() : (_selectedItem?.value ?? _scaleStart);
   const selectedIndex = getIndexFromValue(selectedValue);
   const selectedWidth = calculatePercentFromIndex(selectedIndex);
+
+  const rangeBottomWidth = correctAnswers.length ? calculatePercentFromIndex(getIndexFromValue(correctAnswers[0])) : 0;
+  const rangeTopWidth = correctAnswers.length ? calculatePercentFromIndex(getIndexFromValue(correctAnswers[correctAnswers.length - 1])) : 0;
+  const fillLeft = _isCorrectAnswerShown ? rangeBottomWidth : 0;
+  const fillWidth = _isCorrectAnswerShown ? rangeTopWidth - rangeBottomWidth : selectedWidth;
 
   const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
 
@@ -134,8 +143,8 @@ export default function Slider (props) {
 
           {/* annotate the correct answer range */}
           <div className="slider__number-model-range js-slider-model-range">
-            {_isCorrectAnswerShown &&
-              getCorrectAnswers().map(correctAnswer => {
+            {isModelRangeShown &&
+              correctAnswers.map(correctAnswer => {
                 return (
                   <div
                     className="slider__number-model-answer"
@@ -159,7 +168,7 @@ export default function Slider (props) {
 
           {/* annotate the selected value */}
           <div className="slider__number-answer"></div>
-          {_showScaleIndicator &&
+          {_showScaleIndicator && !isCorrectRangeShown &&
             <div
               className="slider__number-selection js-slider-number-selection a11y-ignore"
               aria-hidden="true"
@@ -224,7 +233,7 @@ export default function Slider (props) {
         ])}
         >
           <div className="slider__item-input-track">
-            <div className="slider__item-input-fill" style={{ width: `${selectedWidth}%` }} />
+            <div className="slider__item-input-fill" style={{ left: `${fillLeft}%`, width: `${fillWidth}%` }} />
           </div>
 
           <input className='slider__item-input js-slider-item-input'


### PR DESCRIPTION
Fixes #184

## Fix
1. **Number range:** When a range-based slider is answered correctly, the **full correct range** is now shown. Previously, only the learner's single chosen value was indicated. `_canShowModelAnswer` must be `true`.

<img width="600" alt="Screenshot 2026-05-28 at 10 57 05 AM" src="https://github.com/user-attachments/assets/f4be053a-a64c-4018-ab7a-ccb56ab5ea15" />

2. **Visible thumb after submission:** The slider thumb now stays visible after a correct submit (marks the learner's pick). It is hidden only during the "show correct answer" view for an incorrect submission. `is-disabled` keeps `cursor: default` to signal the control is non-interactive.

3. **Fill bar issue:** Fixed the fill bar during "show correct answer": it now spans the actual correct range instead of running from the scale start to the range midpoint. Previously a 5-9 range highlighted 5-9 but filled 1-7, which was misleading.

Previous:
<img width="600" alt="Screenshot 2026-05-27 at 3 41 35 PM" src="https://github.com/user-attachments/assets/d898f293-6913-45b3-b97f-304fba38fb8b"/>

Fixed:
<img width="600" alt="Screenshot 2026-05-27 at 3 40 40 PM" src="https://github.com/user-attachments/assets/47c09ff5-5adb-426f-90be-bb4279b9e312"/>

4. **Correct-range colour:** The widget now adds the `show-correct-answer` class whenever the correct range is shown (including on a correct submit), so the existing Vanilla theme rules colour the range circles and fill with the validation/success colour. No companion theme change required. The thumb-hide rule was scoped to `.show-correct-answer.is-incorrect` so the thumb stays visible on a correct submit.

## Testing
1. Use a slider with a `_correctRange` (e.g. `_bottom: 5`, `_top: 9`) and `_canShowModelAnswer: true`.
2. Answer correctly (e.g. 7) and submit. Expect: the full 5-9 range is highlighted in the validation/success colour, the thumb stays visible at your chosen value, and the fill runs to your value.
3. Reset, answer incorrectly (e.g. 2) and submit, then select "Show correct answer". Expect: the 5-9 range is highlighted, no thumb is shown, and the fill spans 5-9 (not 1-7).
4. Toggle "Show your answer" / "Show correct answer" and confirm the views switch correctly.

## Companion issue to create
**Hiding the handle in Confidence Slider** - `adapt-contrib-confidenceSlider` extends `SliderView` and reuses the same `slider__widget` / `slider__item` markup, so it shares slider's compiled thumb CSS. Because confidenceSlider never applies `show-correct-answer`, the changes here leave its handle visible after submit (it was previously hidden). If we want to retain the previous behaviour, confidenceSlider should add its own thumb-hide rule or be updated to decouple from slider's `.show-correct-answer` gating.

After submit:
<img width="600" alt="Screenshot 2026-05-27 at 4 01 57 PM" src="https://github.com/user-attachments/assets/17f3ab11-979f-4d0c-8e6e-04814d80c626"/>

Posted via collaboration with Claude Code